### PR TITLE
chore: removed redundant notif and profile icons

### DIFF
--- a/frontend/src/components/layout/AdminLayout.svelte
+++ b/frontend/src/components/layout/AdminLayout.svelte
@@ -95,20 +95,9 @@
   const items = [
     { name: "Dashboard", icon: "lucide:home", href: "/dashboard" },
     { name: "Tickets", icon: "lucide:ticket", href: "/tickets" },
-    {
-      name: "Notifications",
-      icon: "lucide:bell",
-      href: "/notifications",
-    },
     { name: "History", icon: "lucide:clock", href: "/history" },
     { name: "Help", icon: "lucide:help-circle", href: "/help" },
   ];
-
-  const profileItem = {
-    name: "Profile",
-    icon: "lucide:user-circle",
-    href: "/profile",
-  };
 
   const settingItem = {
     name: "Settings",
@@ -209,7 +198,7 @@
               {notifications}
               {unreadCount}
               {notificationsConfig}
-              viewAllHref="/admin/notifications"
+              viewAllHref="/notifications"
               on:markAsRead={handleMarkAsRead}
               on:notificationClick={handleNotificationClick}
               on:viewAll={handleViewAllNotifications}
@@ -255,13 +244,6 @@
             data-tip={settingItem.name}
           >
             <Icon icon={settingItem.icon} width="24" height="24" />
-          </a>
-          <a
-            href={profileItem.href}
-            class="flex items-center justify-center w-12 h-12 rounded-lg hover:bg-base-200 transition tooltip tooltip-right"
-            data-tip={profileItem.name}
-          >
-            <Icon icon={profileItem.icon} width="24" height="24" />
           </a>
         </li>
       </ul>

--- a/frontend/src/components/layout/StudentLayout.svelte
+++ b/frontend/src/components/layout/StudentLayout.svelte
@@ -118,20 +118,9 @@
     },
     { name: "Tickets", icon: "lucide:ticket", href: "/tickets" },
     { name: "Community Board", icon: "lucide:globe", href: "/community-board" },
-    {
-      name: "Notifications",
-      icon: "lucide:bell",
-      href: "/notifications",
-    },
     { name: "History", icon: "lucide:clock", href: "/history" },
     { name: "Help", icon: "lucide:help-circle", href: "/help" },
   ];
-
-  const profileItem = {
-    name: "Profile",
-    icon: "lucide:user-circle",
-    href: "/profile",
-  };
 
   const settingItem = {
     name: "Settings",
@@ -278,13 +267,6 @@
             data-tip={settingItem.name}
           >
             <Icon icon={settingItem.icon} width="24" height="24" />
-          </a>
-          <a
-            href={profileItem.href}
-            class="flex items-center justify-center w-12 h-12 rounded-lg hover:bg-gray-100 transition tooltip tooltip-right"
-            data-tip={profileItem.name}
-          >
-            <Icon icon={profileItem.icon} width="24" height="24" />
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant notification and profile navigation entries from admin and student layouts and align notification view-all link with the main notifications route.

Enhancements:
- Remove notification items from admin and student side navigation menus to reduce redundancy.
- Remove profile icon buttons from admin and student layout headers.
- Update admin notification dropdown "view all" link to point to the shared /notifications route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Notifications navigation item from application layouts
  * Removed profile menu from sidebar navigation

* **Bug Fixes**
  * Updated notification link path

<!-- end of auto-generated comment: release notes by coderabbit.ai -->